### PR TITLE
Issue 24: Store search parameters in browser URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,40 @@ if (sessionStorage.getItem('lastSearch')) {
   submitNewSearch();
 }
 
+function updateAppURL() {
+  const url = new URL(window.location);
+  url.searchParams.set('sort', sortSelect.value);
+
+  if (queryInput.value) {
+    url.searchParams.set('q', queryInput.value);
+  } else {
+    url.searchParams.delete('q');
+  }
+
+  if (beginDate.value) {
+    url.searchParams.set('begin_date', beginDate.value);
+  } else {
+    url.searchParams.delete('begin_date');
+  }
+
+  if (endDate.value) {
+    url.searchParams.set('end_date', endDate.value);
+  } else {
+    url.searchParams.delete('end_date');
+  }
+
+  let queryFilters = getFilterValuesForURL();
+
+  if (queryFilters.length > 0) {
+    queryFilters = queryFilters.join(' AND ');
+    url.searchParams.set('fq', queryFilters);
+  } else {
+    url.searchParams.delete('fq');
+  }
+
+  window.history.pushState({}, '', url);
+}
+
 function bindEvents() {
   const submitButton = document.getElementById('submit');
 
@@ -26,6 +60,7 @@ function bindEvents() {
     event.preventDefault();
     sortSelect.value = 'relevance';
     searchSettings = getFormData();
+    updateAppURL();
     sessionStorage.setItem('lastSearch', JSON.stringify(searchSettings));
     submitNewSearch();
   });
@@ -248,13 +283,6 @@ function setFormControls() {
   });
 }
 
-function valuesFromFieldset(fieldset) {
-  const elements = Array.from(fieldset.elements);
-  const selectedElements = elements.filter(element => element.checked);
-  const values = selectedElements.map(element => element.value);
-  return values;
-}
-
 function submitNewSearch() {
   toggleLoading();
   resultsPage = 0;
@@ -294,4 +322,11 @@ function toggleLoading() {
     articlesContainer.style.opacity = 1;
     loadingMsg.dataset.visibility = 'hidden';
   }
+}
+
+function valuesFromFieldset(fieldset) {
+  const elements = Array.from(fieldset.elements);
+  const selectedElements = elements.filter(element => element.checked);
+  const values = selectedElements.map(element => element.value);
+  return values;
 }

--- a/main.js
+++ b/main.js
@@ -190,12 +190,12 @@ function getKeywordLink(keyword) {
     
     queryInput.value = event.target.textContent;
     sortSelect.value = 'relevance';
-    searchSettings = getFormData();
 
     if (filterMenu.style.display === 'grid') {
       toggleFilterMenuVisibility();
     }
 
+    updateAppURL();
     submitNewSearch();
     scroll(0, 0);
   });

--- a/main.js
+++ b/main.js
@@ -103,42 +103,11 @@ function displaySearchResults() {
   }
 }
 
-function getSearchComponents() {
-  let components = '';
-
-  if (searchSettings.query) {
-    components += `&q=${searchSettings.query}`;
-  }
-
-  if (searchSettings.begin) {
-    components += `&begin_date=${searchSettings.begin}`;
-  }
-
-  if (searchSettings.end) {
-    components += `&end_date=${searchSettings.end}`;
-  }
-
-  if (searchSettings.sortBy) {
-    components += `&sort=${searchSettings.sortBy}`;
-  }
-
-  let queryFilters = getFilterValuesForURL();
-
-  if (queryFilters.length > 0) {
-    queryFilters = queryFilters.join(' AND ');
-    components += `&fq=${queryFilters}`;
-  }
-
-  return components;
-}
-
 async function fetchArticles() {
   const baseURL = 'https://api.nytimes.com/svc/search/v2/articlesearch.json';
   const key = 'brtQ9fXA0I1ATPctklZe6RcanXZRklYl';
-  let fullURL = `${baseURL}?api-key=${key}&page=${resultsPage}`;
-
-  fullURL += getSearchComponents();
-
+  const searchComponents = window.location.search;
+  const fullURL = baseURL + searchComponents + `&api-key=${key}` + `&page=${resultsPage}`; 
   const response = await fetch(fullURL);
   articles = await response.json();
 }

--- a/main.js
+++ b/main.js
@@ -68,33 +68,41 @@ function displaySearchResults() {
   }
 }
 
-async function fetchArticles() {
-  const baseURL = 'https://api.nytimes.com/svc/search/v2/articlesearch.json';
-  const key = 'brtQ9fXA0I1ATPctklZe6RcanXZRklYl';
-  let fullURL = `${baseURL}?api-key=${key}&page=${resultsPage}`;
+function getSearchComponents() {
+  let components = '';
 
   if (searchSettings.query) {
-    fullURL += `&q=${searchSettings.query}`;
+    components += `&q=${searchSettings.query}`;
   }
 
   if (searchSettings.begin) {
-    fullURL += `&begin_date=${searchSettings.begin}`;
+    components += `&begin_date=${searchSettings.begin}`;
   }
 
   if (searchSettings.end) {
-    fullURL += `&end_date=${searchSettings.end}`;
+    components += `&end_date=${searchSettings.end}`;
   }
 
   if (searchSettings.sortBy) {
-    fullURL += `&sort=${searchSettings.sortBy}`;
+    components += `&sort=${searchSettings.sortBy}`;
   }
 
   let queryFilters = getFilterValuesForURL();
 
   if (queryFilters.length > 0) {
     queryFilters = queryFilters.join(' AND ');
-    fullURL += `&fq=${queryFilters}`;
+    components += `&fq=${queryFilters}`;
   }
+
+  return components;
+}
+
+async function fetchArticles() {
+  const baseURL = 'https://api.nytimes.com/svc/search/v2/articlesearch.json';
+  const key = 'brtQ9fXA0I1ATPctklZe6RcanXZRklYl';
+  let fullURL = `${baseURL}?api-key=${key}&page=${resultsPage}`;
+
+  fullURL += getSearchComponents();
 
   const response = await fetch(fullURL);
   articles = await response.json();

--- a/main.js
+++ b/main.js
@@ -9,31 +9,13 @@ const beginDate = document.getElementById('begin-date');
 const endDate = document.getElementById('end-date');
 const locationInput = document.getElementById('location-search');
 
-let searchSettings = {};
-let articles, resultsPage;
+let searchSettings, articles, resultsPage;
 
 bindEvents();
 
 if (window.location.search) {
   const url = new URL(window.location);
-  searchSettings.query = url.searchParams.get('q');
-  searchSettings.begin = url.searchParams.get('begin');
-  searchSettings.end = url.searchParams.get('end');
-  searchSettings.sortBy = url.searchParams.get('sort');
-  searchSettings.glocation = url.searchParams.get('glocation');
-
-  if (url.searchParams.has('desks')) {
-    searchSettings.newsDesks = url.searchParams.get('desks').split(',');
-  } else {
-    searchSettings.newsDesks = [];
-  }
-
-  if (url.searchParams.has('types')) {
-    searchSettings.materialTypes = url.searchParams.get('types').split(',');
-  } else {
-    searchSettings.materialTypes = [];
-  }
-
+  searchSettings = getSearchParams(url);
   setFormControls();
   submitNewSearch();
 }
@@ -222,6 +204,29 @@ function getKeywordLink(keyword) {
   });
 
   return keywordLink;
+}
+
+function getSearchParams(url) {
+  const params = {};
+  params.query = url.searchParams.get('q');
+  params.begin = url.searchParams.get('begin');
+  params.end = url.searchParams.get('end');
+  params.sortBy = url.searchParams.get('sort');
+  params.glocation = url.searchParams.get('glocation');
+
+  if (url.searchParams.has('desks')) {
+    params.newsDesks = url.searchParams.get('desks').split(',');
+  } else {
+    params.newsDesks = [];
+  }
+
+  if (url.searchParams.has('types')) {
+    params.materialTypes = url.searchParams.get('types').split(',');
+  } else {
+    params.materialTypes = [];
+  }
+
+  return params;
 }
 
 function handleIntersections(entries) {

--- a/main.js
+++ b/main.js
@@ -149,10 +149,10 @@ function getFormData() {
   formData.glocation = locationInput.value.trim();
 
   const newsDeskFieldset = document.getElementById('newsdesk-fieldset');
-  formData.newsDesks = valuesFromFieldset(newsDeskFieldset);
+  formData.newsDesks = getValuesFromFieldset(newsDeskFieldset);
 
   const materialsFieldset = document.getElementById('material-types-fieldset');
-  formData.materialTypes = valuesFromFieldset(materialsFieldset);
+  formData.materialTypes = getValuesFromFieldset(materialsFieldset);
   
   return formData;
 }
@@ -357,7 +357,7 @@ function updateBrowserURL() {
   window.history.pushState({}, '', url);
 }
 
-function valuesFromFieldset(fieldset) {
+function getValuesFromFieldset(fieldset) {
   const elements = Array.from(fieldset.elements);
   const selectedElements = elements.filter(element => element.checked);
   const values = selectedElements.map(element => element.value);

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const beginDate = document.getElementById('begin-date');
 const endDate = document.getElementById('end-date');
 const locationInput = document.getElementById('location-search');
 
-let searchSettings, articles, resultsPage;
+let articles, resultsPage;
 
 bindEvents();
 


### PR DESCRIPTION
Hey @motine, the app now stores search data in the browser URL. Here's the preview link: https://matthewberglund.github.io/nytimes-article-searcher/